### PR TITLE
out of useEffect

### DIFF
--- a/src/hooks/useFetch.tsx
+++ b/src/hooks/useFetch.tsx
@@ -13,10 +13,10 @@ const useFetch = (
   handlePostFetch: Function,
   postData: any
 ) => {
+  handlePreFetch();
   useEffect(() => {
     switch (options.method) {
       case "GET": {
-        handlePreFetch();
         api
           .get(options.pathname)
           .then((res) => {


### PR DESCRIPTION
handlePrefetch was present inside useEffect which caused loading UI to appear after the component mounted. Because of which there was a flashback on the screen. Hence bringing it out of useEffect